### PR TITLE
Improve the debug formatting of `AtomicRefCell`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,6 @@ impl<'b, T: ?Sized + Debug + 'b> Debug for AtomicRefMut<'b, T> {
 
 impl<T: ?Sized + Debug> Debug for AtomicRefCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "AtomicRefCell { ... }".fmt(f)
-     }
+        write!(f, "AtomicRefCell {{ ... }}")
+    }
 }


### PR DESCRIPTION
This commit removes quotation marks from the debug formatting (`{:?}`) of `AtomicRefCell` for the sake of consistency with the standard convention of debug formatting.

```rust
fn fmt_debug() {
    println!("{:?}", (1, RefCell::new(2), AtomicRefCell::new(3), "にゃーん"));
    println!("{:#?}", (1, RefCell::new(2), AtomicRefCell::new(3), "にゃーん"));
}
```

Before:
```
(1, RefCell { value: 2 }, "AtomicRefCell { ... }", "にゃーん")
(
    1,
    RefCell {
        value: 2
    },
    "AtomicRefCell { ... }",
    "にゃーん"
)
```

After:
```
(1, RefCell { value: 2 }, AtomicRefCell { ... }, "にゃーん")
(
    1,
    RefCell {
        value: 2
    },
    AtomicRefCell { ... },
    "にゃーん"
)
```