### PR TITLE
Avoid UB on invalid borrows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,18 +83,24 @@ impl<T: ?Sized> AtomicRefCell<T> {
     /// Immutably borrows the wrapped value.
     #[inline]
     pub fn borrow(&self) -> AtomicRef<T> {
+        // Note: make sure the panic-check here happens before the reference to the inner value
+        // gets created, to make sure this is not UB.
+        let borrow = AtomicBorrowRef::new(&self.borrow);
         AtomicRef {
             value: unsafe { &*self.value.get() },
-            borrow: AtomicBorrowRef::new(&self.borrow),
+            borrow: borrow,
         }
     }
 
     /// Mutably borrows the wrapped value.
     #[inline]
     pub fn borrow_mut(&self) -> AtomicRefMut<T> {
+        // Note: make sure the panic-check here happens before the reference to the inner value
+        // gets created, to make sure this is not UB.
+        let borrow = AtomicBorrowRefMut::new(&self.borrow);
         AtomicRefMut {
             value: unsafe { &mut *self.value.get() },
-            borrow: AtomicBorrowRefMut::new(&self.borrow),
+            borrow: borrow,
         }
     }
 


### PR DESCRIPTION
As the mere existence of aliasing mutable references, not their use
is/may be (the aliasing model is not fully defined yet) an UB, make sure
the references are created only after the check for validity is done and
any illegal situations are prevented by a panic.

It's unlikely the compiler is able to take advantage of in practice,
though.