### PR TITLE
relax lifetime constraints on AtomicRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Threadsafe RefCell"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/bholley/atomic_refcell"
 documentation = "https://docs.rs/atomic_refcell/"
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,8 +381,8 @@ pub struct AtomicRef<'b, T: ?Sized + 'b> {
 
 // SAFETY: `AtomicRef<'_, T> acts as a reference. `AtomicBorrowRef` is a
 // reference to an atomic.
-unsafe impl<'b, T: ?Sized + 'b> Sync for AtomicRef<'b, T> where for<'a> &'a T: Sync {}
-unsafe impl<'b, T: ?Sized + 'b> Send for AtomicRef<'b, T> where for<'a> &'a T: Send {}
+unsafe impl<'b, T: ?Sized> Sync for AtomicRef<'b, T> where for<'a> &'a T: Sync {}
+unsafe impl<'b, T: ?Sized> Send for AtomicRef<'b, T> where for<'a> &'a T: Send {}
 
 impl<'b, T: ?Sized> Deref for AtomicRef<'b, T> {
     type Target = T;
@@ -472,8 +472,8 @@ pub struct AtomicRefMut<'b, T: ?Sized + 'b> {
 
 // SAFETY: `AtomicRefMut<'_, T> acts as a mutable reference.
 // `AtomicBorrowRefMut` is a reference to an atomic.
-unsafe impl<'b, T: ?Sized + 'b> Sync for AtomicRefMut<'b, T> where for<'a> &'a mut T: Sync {}
-unsafe impl<'b, T: ?Sized + 'b> Send for AtomicRefMut<'b, T> where for<'a> &'a mut T: Send {}
+unsafe impl<'b, T: ?Sized> Sync for AtomicRefMut<'b, T> where for<'a> &'a mut T: Sync {}
+unsafe impl<'b, T: ?Sized> Send for AtomicRefMut<'b, T> where for<'a> &'a mut T: Send {}
 
 impl<'b, T: ?Sized> Deref for AtomicRefMut<'b, T> {
     type Target = T;

--- a/tests/async.rs
+++ b/tests/async.rs
@@ -1,0 +1,34 @@
+use std::future::Future;
+
+use atomic_refcell::AtomicRefCell;
+
+fn spawn<Fut>(_future: Fut)
+where
+    Fut: Future<Output = ()> + Send + Sync,
+{
+}
+
+async fn something_async() {}
+
+// see https://github.com/bholley/atomic_refcell/issues/24
+#[test]
+fn test_atomic_ref_in_spawn() {
+    let arc: Box<dyn Fn() -> usize + Send + Sync> = Box::new(|| 42);
+    let a = AtomicRefCell::new(arc);
+    spawn(async move {
+        let x = a.borrow();
+        something_async().await;
+        assert_eq!(x(), 42);
+    });
+}
+
+#[test]
+fn test_atomic_ref_mut_in_spawn() {
+    let arc: Box<dyn Fn() -> usize + Send + Sync> = Box::new(|| 42);
+    let a = AtomicRefCell::new(arc);
+    spawn(async move {
+        let x = a.borrow_mut();
+        something_async().await;
+        assert_eq!(x(), 42);
+    });
+}


### PR DESCRIPTION
fixes and tests the problem described in #24.

I had to set `editon` to 2018, to make the async test work. If this is undesirable, I can move the test to a different crate.

I'm reasonable confident, that the changes are correct, because the compiler would generate [even less restrictive Sync/Send implementation](https://docs.rs/atomic_refcell/0.1.9/atomic_refcell/struct.AtomicRefMut.html#impl-Send-for-AtomicRefMut%3C%27b%2C%20T%3E) in a previous version.
```
impl<'b, T: ?Sized> Send for AtomicRefMut<'b, T> where
    T: Send
``` 

On the other hand, I have to admit, that I'm not really understanding why this change fixes #24... 
`pub struct AtomicRef<'b, T: ?Sized + 'b>` has `T: 'b` after all.

Maybe @Imberflur can weigh in?