### PR TITLE
document why AtomicRef is not clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,6 +396,9 @@ impl<'b, T: ?Sized> Deref for AtomicRef<'b, T> {
 
 impl<'b, T: ?Sized> AtomicRef<'b, T> {
     /// Copies an `AtomicRef`.
+    ///
+    /// Like its [std-counterpart](core::cell::Ref::clone), this type does not implement `Clone`
+    /// to not interfere with cloning the contained type.
     #[inline]
     pub fn clone(orig: &AtomicRef<'b, T>) -> AtomicRef<'b, T> {
         AtomicRef {


### PR DESCRIPTION
This fixes #28 